### PR TITLE
Add CODEOWNERS file and remove dependabot reviewers setting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @robbevp

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,12 +15,8 @@ updates:
         - "stylelint-*"
         - "typescript-eslint"
   open-pull-requests-limit: 10
-  reviewers:
-  - robbevp
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
      interval: monthly
   open-pull-requests-limit: 10
-  reviewers:
-  - robbevp


### PR DESCRIPTION
This removes the deprecated `reviewers` setting from dependabot and adds a CODEOWNERS file